### PR TITLE
Configure flake8_nb

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E305
+exclude = .git,__pycache__
+max-line-length = 90

--- a/.flake8_nb
+++ b/.flake8_nb
@@ -1,0 +1,3 @@
+[flake8_nb]
+exclude = .git,__pycache__
+max-line-length = 120


### PR DESCRIPTION
# Purpose of this PR

To adjust flake 8 configurations when linting Jupyter notebooks